### PR TITLE
Change sidebar overflow to auto

### DIFF
--- a/src/stylesheets/_sidebar.scss
+++ b/src/stylesheets/_sidebar.scss
@@ -42,7 +42,7 @@
 
 .Sidebar__Inner {
     padding: $spacing * 1.5;
-    overflow-y: scroll;
+    overflow-y: auto;
     flex-grow: 1;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
With overflow-y set to scroll, there is an always visible scrollbar on Windows. Setting it to auto will only show a scrollbar when there is actually a need to scroll.